### PR TITLE
Fix Unapproved Verbs and Nested Module Loading Consistency

### DIFF
--- a/GPRegistryPolicy.psd1
+++ b/GPRegistryPolicy.psd1
@@ -27,7 +27,7 @@ Description = 'Module with cmdlets to work with GP Registry Policy .pol files'
 RequiredModules = @()
 
 # Nested Modules - Modules that must be imported into the global environment prior to importing this module
-NestedModules = @('GPRegistryPolicyResource.psd1')
+NestedModules = @('GPRegistryPolicyResource','GpRegistryPolicyParser')
 
 # Minimum version of the Windows PowerShell engine required by this module
 PowerShellVersion = '5.0'
@@ -59,5 +59,6 @@ PrivateData = @{
 
 } # End of PrivateData hashtable
 
-FunctionsToExport = @('Import-GPRegistryPolicy','Export-GPRegistryPolicy','Test-GPRegistryPolicy','Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies')
+FunctionsToExport = @('Import-GPRegistryPolicy','Export-GPRegistryPolicy','Test-GPRegistryPolicy','Import-PolFile','Read-RegistryPolicies','New-RegistrySettingsEntry','New-GPRegistryPolicyFile','Add-RegistryPolicies')
+AliasesToExport = @('Append-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Parse-PolFile')
 }

--- a/GPRegistryPolicy.psm1
+++ b/GPRegistryPolicy.psm1
@@ -22,7 +22,6 @@ data LocalizedData
 }
 
 Import-LocalizedData  LocalizedData -filename GPRegistryPolicy.Strings.psd1
-Import-Module "$PSScriptRoot\GPRegistryPolicyParser.psm1" -DisableNameChecking
 
 $script:SystemAndAdminAccounts = @(
     'NT AUTHORITY\SYSTEM',
@@ -366,7 +365,7 @@ function Import-GPRegistryPolicy
         $Parameters.Add('KeyPrefix', $KeyPrefix)
     }
 
-    $RegistryPolicies = Parse-PolFile -Path $Path
+    $RegistryPolicies = Import-PolFile -Path $Path
 
     foreach ($rp in $RegistryPolicies)
     {
@@ -480,9 +479,9 @@ function Export-GPRegistryPolicy
 
     $RegistryPolicies = Read-RegistryPolicies -Entries $Entries -Division $Division
     
-    Create-GPRegistryPolicyFile -Path $Path
+    New-GPRegistryPolicyFile -Path $Path
 
-    Append-RegistryPolicies -RegistryPolicies $RegistryPolicies -Path $Path
+    Add-RegistryPolicies -RegistryPolicies $RegistryPolicies -Path $Path
 }
 
 
@@ -598,8 +597,8 @@ function Test-GPRegistryPolicy
     # Export the the temp registry key into a file to get expected settings
     Export-GPRegistryPolicy -Path $tempFileExpected -Entries @($tempRegKey) @Parameters
     
-    $ActualRP = Parse-PolFile -Path $tempFileActual
-    $ExpectedRP = Parse-PolFile -Path $tempFileExpected
+    $ActualRP = Import-PolFile -Path $tempFileActual
+    $ExpectedRP = Import-PolFile -Path $tempFileExpected
     
     $ActualRPInJSON = ConvertTo-Json -InputObject $ActualRP
     $ExpectedRPInJSON = ConvertTo-Json -InputObject $ExpectedRP
@@ -664,7 +663,3 @@ Function Assert
         throw $ErrorMessage;
     }
 }
-
-#Export-ModuleMember -Function 'Import-GPRegistryPolicy','Export-GPRegistryPolicy','Test-GPRegistryPolicy'
-#Export-ModuleMember -Function 'Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies'
-Export-ModuleMember -Function 'Import-GPRegistryPolicy','Export-GPRegistryPolicy','Test-GPRegistryPolicy','Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies'

--- a/GPRegistryPolicyParser.psm1
+++ b/GPRegistryPolicyParser.psm1
@@ -169,10 +169,11 @@ Reads a .pol file, parses it and returns an array of Group Policy registry setti
 Specifies the path to the .pol file.
 
 .EXAMPLE
-C:\PS> Parse-PolFile -Path "C:\Registry.pol"
+C:\PS> Import-PolFile -Path "C:\Registry.pol"
 #>
-Function Parse-PolFile
+Function Import-PolFile
 {
+    [Alias('Parse-PolFile')]
     [OutputType([Array])]
     param (
         [Parameter(Mandatory=$true,Position=0)]
@@ -440,8 +441,9 @@ in a .pol file later.
 .PARAMETER RegistryPolicy
 Specifies the registry policy entry.
 #>
-Function Create-RegistrySettingsEntry
+Function New-RegistrySettingsEntry
 {
+    [Alias('Create-RegistrySettingsEntry')]
     [OutputType([Array])]
     param (
 		[Parameter(Mandatory = $true)]
@@ -528,8 +530,9 @@ An array of registry policy entries.
 .PARAMETER Path
 Path to a file (.pol extension)
 #>
-Function Append-RegistryPolicies
+Function Add-RegistryPolicies
 {
+    [alias('Append-RegistryPolicies')]
     param (
 		[Parameter(Mandatory = $true)]
         [GPRegistryPolicy[]]
@@ -543,7 +546,7 @@ Function Append-RegistryPolicies
         
     foreach ($rp in $RegistryPolicies)
     {
-        [Byte[]] $Entry = Create-RegistrySettingsEntry -RegistryPolicy $rp
+        [Byte[]] $Entry = New-RegistrySettingsEntry -RegistryPolicy $rp
         $Entry | Add-Content -Path $Path -Encoding Byte
     }
 }
@@ -588,8 +591,9 @@ Creates a file and initializes it with Group Policy Registry file format signatu
 .PARAMETER Path
 Path to a file (.pol extension)
 #>
-Function Create-GPRegistryPolicyFile
+Function New-GPRegistryPolicyFile
 {
+    [Alias('Create-GPRegistryPolicyFile')]
     param (
         [Parameter(Mandatory)]
         $Path
@@ -746,5 +750,3 @@ Function Convert-StringToInt
 
     return $result
 }
-
-Export-ModuleMember -Function 'Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies'

--- a/GPRegistryPolicyResource.psm1
+++ b/GPRegistryPolicyResource.psm1
@@ -35,5 +35,3 @@ class RegistryPolicy {
         return $this
     }
 }
-
-Export-ModuleMember -Function ''

--- a/README.md
+++ b/README.md
@@ -163,12 +163,12 @@ These cmdlets will allow you to work with .POL files, which contain the registry
 
 ---
 
-## Parse-PolFile
+## Import-PolFile
 Reads a .pol file containing group policy registry entries and returns an array of objects each containing a registry setting.
 
 ### Syntax
 ```
-Parse-PolFile [-Path <string>]  [<CommonParameters>]
+Import-PolFile [-Path <string>]  [<CommonParameters>]
 ```
 
 | Parameter Name | Description                                                                            | 
@@ -177,7 +177,7 @@ Parse-PolFile [-Path <string>]  [<CommonParameters>]
 
 ### Example
 ```
-C:\PS> $RegistrySettings = Parse-PolFile -Path "C:\Registry.pol"
+C:\PS> $RegistrySettings = Import-PolFile -Path "C:\Registry.pol"
 ```
 
 ---
@@ -206,13 +206,13 @@ C:\PS> $RegistrySettings = Read-RegistryPolicies -Divistion 'LocalMachine' -Entr
 
 ---
 
-## Create-RegistrySettingsEntry
+## New-RegistrySettingsEntry
 Creates a .pol file entry byte array from a GPRegistryPolicy instance. This entry can be written
 in a .pol file later.
 
 ### Syntax
 ```
-$RegistrySettings = Create-RegistrySettingsEntry [-RegistryPolicy <GPRegistryPolicy[]>
+$RegistrySettings = New-RegistrySettingsEntry [-RegistryPolicy <GPRegistryPolicy[]>
 ```
 
 | Parameter Name | Description                                                                                          | 
@@ -221,17 +221,17 @@ $RegistrySettings = Create-RegistrySettingsEntry [-RegistryPolicy <GPRegistryPol
 
 ### Example
 ```
-C:\PS> $Entry = Create-RegistrySettingsEntry -RegistryPolicy $GPRegistryPolicyInstance
+C:\PS> $Entry = New-RegistrySettingsEntry -RegistryPolicy $GPRegistryPolicyInstance
 ```
 
 ---
 
-## Append-RegistryPolicies
+## Add-RegistryPolicies
 Appends an array of registry policy entries to a file. The file must alreay have a valid header.
 
 ### Syntax
 ```
-Append-RegistryPolicies [-RegistryPolicies <GPRegistryPolicy[]>] [-Path <string>]
+Add-RegistryPolicies [-RegistryPolicies <GPRegistryPolicy[]>] [-Path <string>]
 ```
 
 | Parameter Name   | Description                                                                                          | 
@@ -241,7 +241,7 @@ Append-RegistryPolicies [-RegistryPolicies <GPRegistryPolicy[]>] [-Path <string>
 
 ### Example
 ```
-C:\PS> Append-RegistryPolicies -RegistryPolicies $RegistryPoliciesInput -Path "C:\Registry.pol"
+C:\PS> Add-RegistryPolicies -RegistryPolicies $RegistryPoliciesInput -Path "C:\Registry.pol"
 ```
 
 ---


### PR DESCRIPTION
#### Change the following exported functions to use approved verbs

| Old Function Name | New Function Name |
|-----------------------|-----------------------|
| Create-RegistrySettingsEntry | New-RegistrySettingsEntry |
| Create-GPRegistryPolicyFile | New-GPRegistryPolicyFile |
| Parse-PolFile | Import-PolFile |
| Append-RegistryPolicies | Add-RegistryPolicies |

Aliases have been added for the old names, so current usage should be unaffected.

#### Change the Module import to Consistently use NestedModules

Currently each of the nested modules is loaded using a different method.  Changed this to both be specified as NestedModules in the main module psd file, and removed the unnecessary Export-ModuleMember commands from each module, as the functions to export are listed in the main module psd file.