### PR TITLE
 Read .pol file with -AsBytestream flag in PS v6+

### DIFF
--- a/GPRegistryPolicyParser.psm1
+++ b/GPRegistryPolicyParser.psm1
@@ -184,7 +184,12 @@ Function Parse-PolFile
     $index = 0
 
     [string] $policyContents = Get-Content $Path -Raw
-    [byte[]] $policyContentInBytes = Get-Content $Path -Raw -Encoding Byte
+
+    if ($psversiontable.PSVersion.Major -lt 6) {
+        [byte[]] $policyContentInBytes = Get-Content $Path -Raw -Encoding Byte
+    } else {
+        [byte[]] $policyContentInBytes = Get-Content $Path -AsByteStream
+    }
 
     # 4 bytes are the signature PReg
     $signature = [System.Text.Encoding]::ASCII.GetString($policyContents[0..3])


### PR DESCRIPTION
As of Powershell version 6, reading the contents of a file using `Get-Content <path-to-file> -Raw -Encoding Byte` no longer works. `Get-Content <path-to-file> -AsByteStream` should be used instead.

See https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/get-content?view=powershell-6#parameters