### PR TITLE
Export New-GPRegistryPolicy

### DIFF
--- a/GPRegistryPolicy.psm1
+++ b/GPRegistryPolicy.psm1
@@ -667,4 +667,4 @@ Function Assert
 
 #Export-ModuleMember -Function 'Import-GPRegistryPolicy','Export-GPRegistryPolicy','Test-GPRegistryPolicy'
 #Export-ModuleMember -Function 'Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies'
-Export-ModuleMember -Function 'Import-GPRegistryPolicy','Export-GPRegistryPolicy','Test-GPRegistryPolicy','Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies'
+Export-ModuleMember -Function 'Import-GPRegistryPolicy','Export-GPRegistryPolicy','Test-GPRegistryPolicy','Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies','New-GPRegistryPolicy'

--- a/GPRegistryPolicyParser.psm1
+++ b/GPRegistryPolicyParser.psm1
@@ -747,4 +747,4 @@ Function Convert-StringToInt
     return $result
 }
 
-Export-ModuleMember -Function 'Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies'
+Export-ModuleMember -Function 'Parse-PolFile','Read-RegistryPolicies','Create-RegistrySettingsEntry','Create-GPRegistryPolicyFile','Append-RegistryPolicies','New-GPRegistryPolicy'


### PR DESCRIPTION
Export New-GPRegistryPolicy  in order to create GPRegistryPolicy instances for other cmdlets